### PR TITLE
fix: vhost の docroot を gomander のパスに合わせる【カットオーバー当日までマージ禁止】

### DIFF
--- a/dist/servers/precure.ml.conf
+++ b/dist/servers/precure.ml.conf
@@ -5,7 +5,7 @@ server {
   access_log syslog:server=localhost,tag=nginx_curesta,severity=info combined;
 
   location /.well-known/acme-challenge/ {
-    root /usr/local/www/mastodon/public;
+    root /home/mastodon/repos/mastodon/public;
   }
   location / {
     return 301 https://$host$request_uri;
@@ -88,7 +88,7 @@ server {
     proxy_pass http://localhost:3000;
   }
   location ~ ^/(packs|system|assets|emoji)/ {
-    root /usr/local/www/mastodon/public;
+    root /home/mastodon/repos/mastodon/public;
   }
   location = /custom.css {
     include /usr/local/etc/nginx/mulukhiya_proxy.conf;
@@ -100,10 +100,10 @@ server {
   }
   location ~ \.(js|json|css|map)$ {
     add_header Cache-Control "public, max-age=0";
-    root /usr/local/www/mastodon/public;
+    root /home/mastodon/repos/mastodon/public;
   }
   location ~ \.(html|jpg|png|gif|mp4|xml|ico|svg|txt|ogg|mp3)$ {
-    root /usr/local/www/mastodon/public;
+    root /home/mastodon/repos/mastodon/public;
   }
 
   location ^~ /media {
@@ -185,7 +185,7 @@ server {
   error_page 503 @maintenance;
 
   location @maintenance {
-    root /usr/local/www/mastodon/public;
+    root /home/mastodon/repos/mastodon/public;
     try_files /maintenance.html =503;
   }
 


### PR DESCRIPTION
## ⚠ マージのタイミング

**lbock を停止するまでマージしないこと。** この vhost は lbock の nginx へ symlink されているため、先にマージして lbock で `git pull` すると **lbock の nginx が壊れる**（root が存在しないパスを指す）。

カットオーバー当日、lbock を停止した後にマージする。手順は pooza/chubo2 の `docs/infra-note.md`「キュアスタ！カットオーバー手順」事前作業 1 を参照。

## 変更

キュアスタ！を lbock（さくら VPS）から gomander（Linode）へ移行するにあたり、Mastodon の置き場が変わる。

| | lbock | gomander |
| --- | --- | --- |
| Mastodon | `/usr/local/www/mastodon` | `/home/mastodon/repos/mastodon` |

gomander 側は zugoga / shallu と同じ chubo2 の規約に揃えており、node yaml でも宣言済み。`delmulin` ブランチの vhost は既にこの形。

`dist/servers/precure.ml.conf` の `root` が 5 箇所とも旧パスのままだと:

- `location ~ ^/(packs|system|assets|emoji)/` — **静的アセットが全て 404**
- `location /.well-known/acme-challenge/` — **ACME の HTTP-01 検証が通らない**（証明書更新が止まる）

rc スクリプト（`dist/freebsd/mastodon-*`）は `$mastodon_path`（sysrc）を参照するのでパス非依存。**問題は vhost だけ。**

## 範囲外

`feed.precure.ml` / `rubicure.precure.ml` は移行対象外（撤去）なので触っていない。gomander には vhost を置かない。整理は移行完了後に別途。

🤖 Generated with [Claude Code](https://claude.com/claude-code)