### PR TITLE
ダイスキーのカスタム絵文字カテゴリを同期する tootctl emoji sync (#945)

### DIFF
--- a/app/lib/misskey_emoji_sync.rb
+++ b/app/lib/misskey_emoji_sync.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+# 姉妹 Misskey サーバーのカスタム絵文字を正として、こちらの絵文字とカテゴリを揃える。
+#
+# 新規登録は常に Misskey 側で行う運用なので、同期は一方向で、削除は一切行わない。
+# 向こうに無いローカル絵文字は（向こうで削除されたものも含めて）触らずに報告するだけ。
+#
+# 管理画面の「ローカルにコピー」が呼ぶ CustomEmoji#copy! は shortcode と image しか
+# 写さずカテゴリを引き継がないため、その穴を埋めるのが主目的。
+class MisskeyEmojiSync
+  class Error < StandardError; end
+
+  Plan = Struct.new(
+    :copy,
+    :recategorize,
+    :obsolete_categories,
+    :stale_featured_categories,
+    :orphans,
+    :awaiting_federation,
+    :unsyncable,
+    keyword_init: true
+  )
+
+  attr_reader :domain
+
+  def initialize(origin)
+    @domain = origin.to_s.strip.sub(%r{\Ahttps?://}i, '').chomp('/')
+
+    raise Error, "Not a valid origin: #{origin}" if @domain.blank? || @domain.include?('/')
+  end
+
+  def plan
+    @plan ||= build_plan
+  end
+
+  def apply!
+    # 画像のアップロードを伴うので、カテゴリの張り替えとは分けてトランザクションの外で行う
+    plan.copy.each(&:copy!)
+
+    ApplicationRecord.transaction do
+      plan.recategorize.each do |change|
+        CustomEmoji.local.find_by!(shortcode: change[:shortcode]).update!(category: category_for(change[:to]))
+      end
+
+      CustomEmojiCategory.where(name: plan.stale_featured_categories).update_all(featured_emoji_id: nil) if plan.stale_featured_categories.any?
+      CustomEmojiCategory.where(name: plan.obsolete_categories).destroy_all if plan.obsolete_categories.any?
+    end
+  end
+
+  private
+
+  def build_plan
+    desired = fetch_desired_categories
+    local   = CustomEmoji.local.includes(:category).index_by(&:shortcode)
+    remote  = CustomEmoji.where(domain: domain).index_by(&:shortcode)
+
+    # 向こうの名前がこちらの shortcode 規則を満たさないものは、リモート絵文字としても
+    # 連合してこないので永久に持ち込めない
+    unsyncable = desired.keys.grep_v(CustomEmoji::SHORTCODE_ONLY_RE)
+    missing    = desired.keys - unsyncable - local.keys
+
+    # 向こうに現存するものだけコピーする。リモート絵文字は向こうで削除されても残るため、
+    # 絞らないと削除済みの絵文字を蘇らせてしまう
+    copy = missing.filter_map { |shortcode| remote[shortcode] }.sort_by(&:shortcode)
+
+    # 最終的なカテゴリの割り当て。空になるカテゴリの判定に使う
+    assignments  = {}
+    recategorize = []
+
+    local.each_value do |emoji|
+      current = emoji.category&.name
+
+      unless desired.key?(emoji.shortcode)
+        assignments[emoji.shortcode] = current
+        next
+      end
+
+      assignments[emoji.shortcode] = desired[emoji.shortcode]
+      recategorize << { shortcode: emoji.shortcode, from: current, to: desired[emoji.shortcode] } if desired[emoji.shortcode] != current
+    end
+
+    copy.each do |emoji|
+      assignments[emoji.shortcode] = desired[emoji.shortcode]
+      recategorize << { shortcode: emoji.shortcode, from: nil, to: desired[emoji.shortcode] } unless desired[emoji.shortcode].nil?
+    end
+
+    used     = assignments.values.compact.to_set
+    obsolete = CustomEmojiCategory.pluck(:name).reject { |name| used.include?(name) }.sort
+
+    Plan.new(
+      copy: copy,
+      recategorize: recategorize.sort_by { |change| change[:shortcode] },
+      obsolete_categories: obsolete,
+      stale_featured_categories: stale_featured_categories(assignments, obsolete),
+      orphans: (local.keys - desired.keys).sort,
+      awaiting_federation: (missing - remote.keys).sort,
+      unsyncable: unsyncable.sort
+    )
+  end
+
+  # 注目絵文字が別のカテゴリへ移ってしまったカテゴリ。ぶら下がった参照を落とす
+  def stale_featured_categories(assignments, obsolete)
+    CustomEmojiCategory.where.not(featured_emoji_id: nil).includes(:featured_emoji).filter_map do |category|
+      next if obsolete.include?(category.name)
+
+      shortcode = category.featured_emoji&.shortcode
+      category.name unless shortcode.present? && assignments[shortcode] == category.name
+    end.sort
+  end
+
+  def fetch_desired_categories
+    json = Request.new(:get, "https://#{domain}/api/emojis").perform do |response|
+      raise Error, "#{domain} returned HTTP #{response.code}" unless response.code == 200
+
+      JSON.parse(response.body_with_limit)
+    end
+
+    raise Error, "Unexpected response from #{domain}" unless json.is_a?(Hash) && json['emojis'].is_a?(Array)
+    raise Error, "No custom emoji returned by #{domain}" if json['emojis'].empty?
+
+    json['emojis'].to_h { |emoji| [emoji['name'], emoji['category'].presence] }
+  end
+
+  def category_for(name)
+    return if name.nil?
+
+    @categories ||= {}
+    @categories[name] ||= CustomEmojiCategory.find_or_create_by!(name: name)
+  end
+end

--- a/lib/mastodon/cli/emoji.rb
+++ b/lib/mastodon/cli/emoji.rb
@@ -133,6 +133,9 @@ module Mastodon::CLI
       say('OK', :green)
     end
 
+    # 未連合の絵文字は初回や新設サーバーで数百件になりうるので、通知に流せる長さに畳む
+    REPORTED_SHORTCODES = 10
+
     option :dry_run, type: :boolean, default: true
     desc 'sync ORIGIN', 'Sync custom emoji and their categories from a sister Misskey server at ORIGIN'
     long_desc <<-LONG_DESC
@@ -166,14 +169,20 @@ module Mastodon::CLI
 
       say("Copied #{plan.copy.size}, recategorized #{plan.recategorize.size}, removed #{plan.obsolete_categories.size} empty categories#{dry_run_mode_suffix}", :green)
 
-      say("#{plan.awaiting_federation.size} emoji on #{syncer.domain} have not federated here yet, post them there to bring them over: #{plan.awaiting_federation.join(', ')}", :yellow) if plan.awaiting_federation.any?
-      say("#{plan.orphans.size} local emoji are unknown to #{syncer.domain} and were left untouched: #{plan.orphans.join(', ')}", :yellow) if plan.orphans.any?
-      say("#{plan.unsyncable.size} emoji on #{syncer.domain} cannot be represented here, names must match #{CustomEmoji::SHORTCODE_RE_FRAGMENT}: #{plan.unsyncable.join(', ')}", :yellow) if plan.unsyncable.any?
+      say("#{plan.awaiting_federation.size} emoji on #{syncer.domain} have not federated here yet, post them there to bring them over: #{summarize_shortcodes(plan.awaiting_federation)}", :yellow) if plan.awaiting_federation.any?
+      say("#{plan.orphans.size} local emoji are unknown to #{syncer.domain} and were left untouched: #{summarize_shortcodes(plan.orphans)}", :yellow) if plan.orphans.any?
+      say("#{plan.unsyncable.size} emoji on #{syncer.domain} cannot be represented here, names must match #{CustomEmoji::SHORTCODE_RE_FRAGMENT}: #{summarize_shortcodes(plan.unsyncable)}", :yellow) if plan.unsyncable.any?
     rescue MisskeyEmojiSync::Error => e
       fail_with_message e.message
     end
 
     private
+
+    def summarize_shortcodes(shortcodes)
+      return shortcodes.join(', ') if shortcodes.size <= REPORTED_SHORTCODES
+
+      "#{shortcodes.first(REPORTED_SHORTCODES).join(', ')} and #{shortcodes.size - REPORTED_SHORTCODES} more"
+    end
 
     def color(green, _yellow, red)
       if !green.zero? && red.zero?

--- a/lib/mastodon/cli/emoji.rb
+++ b/lib/mastodon/cli/emoji.rb
@@ -133,6 +133,46 @@ module Mastodon::CLI
       say('OK', :green)
     end
 
+    option :dry_run, type: :boolean, default: true
+    desc 'sync ORIGIN', 'Sync custom emoji and their categories from a sister Misskey server at ORIGIN'
+    long_desc <<-LONG_DESC
+      Aligns local custom emoji with the sister Misskey server at ORIGIN,
+      which is treated as the single source of truth.
+
+      Emoji that already federated from ORIGIN but have no local counterpart
+      are copied locally, every local emoji known to ORIGIN has its category
+      overwritten with the one used there, and categories left without any
+      emoji are removed.
+
+      Nothing is ever deleted, and local emoji unknown to ORIGIN are left
+      untouched and reported instead. Running this repeatedly is safe, since
+      it always writes only what differs.
+
+      Nothing is written unless --no-dry-run is given.
+    LONG_DESC
+    def sync(origin)
+      syncer = MisskeyEmojiSync.new(origin)
+      plan   = syncer.plan
+
+      say("Syncing custom emoji from #{syncer.domain}#{dry_run_mode_suffix}")
+
+      if dry_run?
+        plan.copy.each { |emoji| say("  copy #{emoji.shortcode}") }
+        plan.recategorize.each { |change| say("  #{change[:shortcode]}: #{change[:from] || '(none)'} -> #{change[:to] || '(none)'}") }
+        plan.obsolete_categories.each { |name| say("  remove empty category #{name}") }
+      else
+        syncer.apply!
+      end
+
+      say("Copied #{plan.copy.size}, recategorized #{plan.recategorize.size}, removed #{plan.obsolete_categories.size} empty categories#{dry_run_mode_suffix}", :green)
+
+      say("#{plan.awaiting_federation.size} emoji on #{syncer.domain} have not federated here yet, post them there to bring them over: #{plan.awaiting_federation.join(', ')}", :yellow) if plan.awaiting_federation.any?
+      say("#{plan.orphans.size} local emoji are unknown to #{syncer.domain} and were left untouched: #{plan.orphans.join(', ')}", :yellow) if plan.orphans.any?
+      say("#{plan.unsyncable.size} emoji on #{syncer.domain} cannot be represented here, names must match #{CustomEmoji::SHORTCODE_RE_FRAGMENT}: #{plan.unsyncable.join(', ')}", :yellow) if plan.unsyncable.any?
+    rescue MisskeyEmojiSync::Error => e
+      fail_with_message e.message
+    end
+
     private
 
     def color(green, _yellow, red)

--- a/spec/fork/misskey_emoji_sync_spec.rb
+++ b/spec/fork/misskey_emoji_sync_spec.rb
@@ -1,0 +1,188 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'mastodon/cli/emoji'
+
+# 姉妹 Misskey サーバー（ダイスキー）からカスタム絵文字とカテゴリを引き取る同期（#945）。
+#
+# 「向こうが正・こちらは完全上書き・削除はしない」という運用上の約束をここで固定する。
+# とくに「向こうで削除された絵文字を蘇らせない」「向こうに無いローカル絵文字を消さない」は、
+# 壊れると利用者の目に見える形で事故になるので、正のテストとして持っておく。
+RSpec.describe MisskeyEmojiSync do
+  subject(:syncer) { described_class.new('https://misskey.example') }
+
+  let(:origin_emojis) { [{ name: 'kept', category: 'Greetings' }] }
+
+  before do
+    stub_request(:get, 'https://misskey.example/api/emojis')
+      .to_return(status: 200, body: { emojis: origin_emojis }.to_json, headers: { 'Content-Type' => 'application/json' })
+  end
+
+  describe '#domain' do
+    it 'accepts an origin with or without a scheme and trailing slash' do
+      expect([described_class.new('https://misskey.example/').domain, described_class.new('misskey.example').domain])
+        .to all(eq('misskey.example'))
+    end
+
+    it 'rejects an origin that is not a bare host' do
+      expect { described_class.new('https://misskey.example/api') }.to raise_error(described_class::Error)
+    end
+  end
+
+  describe '#plan' do
+    context 'with a local emoji categorized differently than on the origin' do
+      before { Fabricate(:custom_emoji, shortcode: 'kept', category: Fabricate(:custom_emoji_category, name: 'Stale')) }
+
+      it 'plans to overwrite the category and drop the category left empty' do
+        expect(syncer.plan.recategorize).to eq [{ shortcode: 'kept', from: 'Stale', to: 'Greetings' }]
+        expect(syncer.plan.obsolete_categories).to eq ['Stale']
+      end
+    end
+
+    context 'with a local emoji already categorized as on the origin' do
+      before { Fabricate(:custom_emoji, shortcode: 'kept', category: Fabricate(:custom_emoji_category, name: 'Greetings')) }
+
+      it 'plans nothing' do
+        expect(syncer.plan.recategorize).to be_empty
+        expect(syncer.plan.obsolete_categories).to be_empty
+      end
+    end
+
+    context 'with a federated emoji that has no local counterpart' do
+      before { Fabricate(:custom_emoji, shortcode: 'kept', domain: 'misskey.example') }
+
+      it 'plans to copy it' do
+        expect(syncer.plan.copy.map(&:shortcode)).to eq ['kept']
+        expect(syncer.plan.awaiting_federation).to be_empty
+      end
+    end
+
+    context 'with a federated emoji the origin no longer lists' do
+      before { Fabricate(:custom_emoji, shortcode: 'withdrawn', domain: 'misskey.example') }
+
+      it 'does not plan to copy it' do
+        expect(syncer.plan.copy).to be_empty
+      end
+    end
+
+    context 'with a local emoji unknown to the origin' do
+      before { Fabricate(:custom_emoji, shortcode: 'ours_only', category: Fabricate(:custom_emoji_category, name: 'Ours')) }
+
+      it 'reports it as an orphan and keeps its category alive' do
+        expect(syncer.plan.orphans).to eq ['ours_only']
+        expect(syncer.plan.recategorize).to be_empty
+        expect(syncer.plan.obsolete_categories).to be_empty
+      end
+    end
+
+    context 'with an emoji on the origin that has not federated here yet' do
+      it 'reports it as awaiting federation' do
+        expect(syncer.plan.awaiting_federation).to eq ['kept']
+      end
+    end
+
+    context 'with an emoji on the origin whose name is not a valid shortcode here' do
+      let(:origin_emojis) { [{ name: 'wa-i', category: 'Deprecated' }, { name: 'a', category: 'Feelings' }] }
+
+      it 'reports it as unsyncable rather than awaiting federation' do
+        expect(syncer.plan.unsyncable).to eq %w(a wa-i)
+        expect(syncer.plan.awaiting_federation).to be_empty
+      end
+    end
+
+    context 'when the origin cannot be reached' do
+      before { stub_request(:get, 'https://misskey.example/api/emojis').to_return(status: 500) }
+
+      it 'raises' do
+        expect { syncer.plan }.to raise_error(described_class::Error, /HTTP 500/)
+      end
+    end
+
+    context 'when the origin returns no emoji' do
+      let(:origin_emojis) { [] }
+
+      it 'raises rather than treating every category as empty' do
+        expect { syncer.plan }.to raise_error(described_class::Error, /No custom emoji/)
+      end
+    end
+  end
+
+  describe '#apply!' do
+    context 'with a local emoji categorized differently than on the origin' do
+      let!(:emoji) { Fabricate(:custom_emoji, shortcode: 'kept', category: Fabricate(:custom_emoji_category, name: 'Stale')) }
+
+      it 'overwrites the category and removes the one left empty' do
+        expect { syncer.apply! }
+          .to change { emoji.reload.category.name }.from('Stale').to('Greetings')
+          .and change { CustomEmojiCategory.exists?(name: 'Stale') }.from(true).to(false)
+      end
+
+      it 'converges, so a second run has nothing left to do' do
+        syncer.apply!
+
+        expect(described_class.new('https://misskey.example').plan.recategorize).to be_empty
+      end
+    end
+
+    context 'with a federated emoji that has no local counterpart' do
+      before { Fabricate(:custom_emoji, shortcode: 'kept', domain: 'misskey.example') }
+
+      it 'copies it locally with the category from the origin' do
+        expect { syncer.apply! }
+          .to change { CustomEmoji.local.exists?(shortcode: 'kept') }.from(false).to(true)
+
+        expect(CustomEmoji.local.find_by(shortcode: 'kept').category.name).to eq 'Greetings'
+      end
+    end
+
+    context 'with a local emoji unknown to the origin' do
+      let!(:emoji) { Fabricate(:custom_emoji, shortcode: 'ours_only', category: Fabricate(:custom_emoji_category, name: 'Ours')) }
+
+      it 'never deletes it' do
+        expect { syncer.apply! }
+          .to not_change { emoji.reload.category.name }
+          .and(not_change { CustomEmoji.local.count })
+      end
+    end
+
+    context 'with a category whose featured emoji moved away' do
+      let!(:category) { Fabricate(:custom_emoji_category, name: 'Greetings') }
+      let!(:emoji) { Fabricate(:custom_emoji, shortcode: 'ours_only', category: category) }
+
+      before do
+        Fabricate(:custom_emoji, shortcode: 'kept', category: category)
+        category.update!(featured_emoji: emoji)
+        emoji.update!(category: Fabricate(:custom_emoji_category, name: 'Ours'))
+      end
+
+      it 'clears the dangling reference' do
+        expect { syncer.apply! }.to change { category.reload.featured_emoji_id }.from(emoji.id).to(nil)
+      end
+    end
+  end
+
+  describe Mastodon::CLI::Emoji, type: :cli do
+    subject { cli.invoke(:sync, ['https://misskey.example'], options) }
+
+    let(:cli) { described_class.new }
+    let(:options) { { dry_run: true } }
+
+    let!(:emoji) { Fabricate(:custom_emoji, shortcode: 'kept', category: Fabricate(:custom_emoji_category, name: 'Stale')) }
+
+    it 'reports what it would do without writing anything' do
+      expect { subject }
+        .to output_results('kept: Stale -> Greetings', '(DRY RUN)')
+        .and(not_change { emoji.reload.category.name })
+    end
+
+    context 'with --no-dry-run' do
+      let(:options) { { dry_run: false } }
+
+      it 'writes and reports counts' do
+        expect { subject }
+          .to output_results('Copied 0, recategorized 1, removed 1 empty categories')
+          .and change { emoji.reload.category.name }.from('Stale').to('Greetings')
+      end
+    end
+  end
+end

--- a/spec/fork/misskey_emoji_sync_spec.rb
+++ b/spec/fork/misskey_emoji_sync_spec.rb
@@ -184,5 +184,15 @@ RSpec.describe MisskeyEmojiSync do
           .and change { emoji.reload.category.name }.from('Stale').to('Greetings')
       end
     end
+
+    # 新設サーバーや初回は未連合が数百件になる。通知へ流せる長さに畳まれること
+    context 'with more emoji awaiting federation than the report lists' do
+      let(:origin_emojis) { (1..15).map { |i| { name: format('pending_%02d', i), category: 'Greetings' } } + [{ name: 'kept', category: 'Greetings' }] }
+
+      it 'truncates the list' do
+        expect { subject }
+          .to output_results('15 emoji on misskey.example have not federated here yet', 'pending_10 and 5 more')
+      end
+    end
   end
 end


### PR DESCRIPTION
Closes #945

## 何をするか

`tootctl emoji sync <origin>` を追加する。姉妹 Misskey サーバー（ダイスキー）を正として、

1. `<origin>/api/emojis` から `name → category` を取得
2. リモート絵文字のうち**ローカルに同 shortcode が無いものだけ** `copy!`
3. ローカル絵文字のカテゴリを、向こうの文字列**そのまま**で上書き（階層は `ダイ大用語/名言` のようにフルパス）
4. 空になった `CustomEmojiCategory` を削除
5. レポート出力

既定は dry-run。書き込むには `--no-dry-run` が要る。

```
bundle exec tootctl emoji sync https://misskey.delmulin.com
bundle exec tootctl emoji sync https://misskey.delmulin.com --no-dry-run
```

## やらないこと

- **削除は一切しない。** 向こうに無いローカル絵文字は報告するだけで触らない
- **向こうで削除済みの絵文字を蘇らせない。** リモート絵文字レコードは向こうで削除されても残るため、コピー対象を「向こうが現に列挙しているもの」に絞っている
- 双方向同期はしない。新規登録は常にダイスキー側で行う運用のため

## 本番データでの検証結果

デルムリン丼の絵文字構成をテスト DB に写し、実際の `https://misskey.delmulin.com/api/emojis` を引いて `plan` を計算した結果。公開 API 同士を突き合わせて独立に算出した数値と一致した。

| 項目 | 件数 |
|------|------|
| コピー | 0 |
| カテゴリ張り替え | 224 |
| 削除される空カテゴリ | 8 |
| 孤児（向こうに無い・触らない） | 5 |
| 未連合（報告投稿待ち） | 9 |
| 同期不可（shortcode 規則） | 2 |

- カテゴリ張り替え 224 件には、**現在未分類の 40 件**が含まれる。ダイスキー側は全 759 件にカテゴリが設定済みなので、未分類は完全に解消する
- 削除される 8 カテゴリのうち 2 つ（`ダイ大一般` / `奥義`）は既に絵文字ゼロ。残り 6 つが今回の同期で空になる
- 同期不可の 2 件は `a`（1 文字）と `wa-i`（ハイフン）。`CustomEmoji::SHORTCODE_ONLY_RE` を満たさないためリモート絵文字としても連合してこない。`a` はダイスキー側でショートコードを付け替える予定

## 実装メモ

- 実装本体は upstream が触らない `app/lib/misskey_emoji_sync.rb` に置き、`lib/mastodon/cli/emoji.rb` への追記は Thor のコマンド定義だけに留めた。`bshockdon` からのマージで衝突しても解決が軽く済むようにするため
- 当面 `delmulin` ブランチにだけ入れる。コンフリクトが煩わしくなったら `bshockdon` へ移す
- 何度流しても差分だけを書くので冪等。途中で失敗しても流し直せば収束する
- カテゴリの張り替えと空カテゴリの削除はトランザクションに入れた。画像アップロードを伴う `copy!` だけは外に出してある
- 生 SQL ではなく `update!` を通している。`CustomEmoji` の `after_commit :remove_entity_cache` を経由しないとキャッシュが古いまま残るため

## テスト

`spec/fork/misskey_emoji_sync_spec.rb`（18 例）。`spec/lib` は fork-ci の対象外なので、CI が回す `spec/fork` に置いた。

```
bundle exec rspec spec/fork
38 examples, 0 failures
```
