### PR TITLE
長すぎる名前を弾き、コピー失敗でカテゴリ同期を巻き添えにしない (#945)

### DIFF
--- a/app/lib/misskey_emoji_sync.rb
+++ b/app/lib/misskey_emoji_sync.rb
@@ -33,13 +33,26 @@ class MisskeyEmojiSync
     @plan ||= build_plan
   end
 
+  # コピーに失敗した絵文字。apply! を呼ぶまでは空
+  def copy_failures
+    @copy_failures ||= []
+  end
+
   def apply!
-    # 画像のアップロードを伴うので、カテゴリの張り替えとは分けてトランザクションの外で行う
-    plan.copy.each(&:copy!)
+    # 画像のアップロードを伴うので、カテゴリの張り替えとは分けてトランザクションの外で行う。
+    # 個々のコピーの失敗で本命のカテゴリ同期まで巻き添えにしないよう、拾って続行する
+    plan.copy.each do |emoji|
+      emoji.copy!
+    rescue ActiveRecord::RecordInvalid => e
+      copy_failures << { shortcode: emoji.shortcode, message: e.record.errors.full_messages.join(', ') }
+    end
 
     ApplicationRecord.transaction do
       plan.recategorize.each do |change|
-        CustomEmoji.local.find_by!(shortcode: change[:shortcode]).update!(category: category_for(change[:to]))
+        emoji = CustomEmoji.local.find_by(shortcode: change[:shortcode])
+        next if emoji.nil? # コピーに失敗した絵文字
+
+        emoji.update!(category: category_for(change[:to]))
       end
 
       CustomEmojiCategory.where(name: plan.stale_featured_categories).update_all(featured_emoji_id: nil) if plan.stale_featured_categories.any?
@@ -54,9 +67,11 @@ class MisskeyEmojiSync
     local   = CustomEmoji.local.includes(:category).index_by(&:shortcode)
     remote  = CustomEmoji.where(domain: domain).index_by(&:shortcode)
 
-    # 向こうの名前がこちらの shortcode 規則を満たさないものは、リモート絵文字としても
-    # 連合してこないので永久に持ち込めない
-    unsyncable = desired.keys.grep_v(CustomEmoji::SHORTCODE_ONLY_RE)
+    # 向こうの名前がこちらの shortcode 規則を満たさないものは持ち込めない。
+    # 長さの上限はローカル絵文字とリモート絵文字で違う（128 / 2048）ので、規則を満たすか
+    # どうかはローカル側の上限で判断する。Misskey の name は varchar(128) で偶然一致して
+    # いるが、その一致に頼らず自分で弾く
+    unsyncable = desired.keys.reject { |shortcode| syncable_shortcode?(shortcode) }
     missing    = desired.keys - unsyncable - local.keys
 
     # 向こうに現存するものだけコピーする。リモート絵文字は向こうで削除されても残るため、
@@ -106,6 +121,10 @@ class MisskeyEmojiSync
       shortcode = category.featured_emoji&.shortcode
       category.name unless shortcode.present? && assignments[shortcode] == category.name
     end.sort
+  end
+
+  def syncable_shortcode?(shortcode)
+    shortcode.match?(CustomEmoji::SHORTCODE_ONLY_RE) && shortcode.length <= CustomEmoji::MAX_SHORTCODE_SIZE
   end
 
   def fetch_desired_categories

--- a/app/lib/misskey_emoji_sync.rb
+++ b/app/lib/misskey_emoji_sync.rb
@@ -38,11 +38,18 @@ class MisskeyEmojiSync
     @copy_failures ||= []
   end
 
+  # 実際に書き込めた件数。コピーが失敗するとカテゴリ張り替えも 1 件落ちるので、
+  # 計画値をそのまま報告すると実施していない件数を報告することになる
+  def applied
+    @applied ||= { copied: 0, recategorized: 0, removed_categories: 0 }
+  end
+
   def apply!
     # 画像のアップロードを伴うので、カテゴリの張り替えとは分けてトランザクションの外で行う。
     # 個々のコピーの失敗で本命のカテゴリ同期まで巻き添えにしないよう、拾って続行する
     plan.copy.each do |emoji|
       emoji.copy!
+      applied[:copied] += 1
     rescue ActiveRecord::RecordInvalid => e
       copy_failures << { shortcode: emoji.shortcode, message: e.record.errors.full_messages.join(', ') }
     end
@@ -53,10 +60,11 @@ class MisskeyEmojiSync
         next if emoji.nil? # コピーに失敗した絵文字
 
         emoji.update!(category: category_for(change[:to]))
+        applied[:recategorized] += 1
       end
 
       CustomEmojiCategory.where(name: plan.stale_featured_categories).update_all(featured_emoji_id: nil) if plan.stale_featured_categories.any?
-      CustomEmojiCategory.where(name: plan.obsolete_categories).destroy_all if plan.obsolete_categories.any?
+      applied[:removed_categories] = CustomEmojiCategory.where(name: plan.obsolete_categories).destroy_all.size if plan.obsolete_categories.any?
     end
   end
 

--- a/lib/mastodon/cli/emoji.rb
+++ b/lib/mastodon/cli/emoji.rb
@@ -163,17 +163,19 @@ module Mastodon::CLI
         plan.copy.each { |emoji| say("  copy #{emoji.shortcode}") }
         plan.recategorize.each { |change| say("  #{change[:shortcode]}: #{change[:from] || '(none)'} -> #{change[:to] || '(none)'}") }
         plan.obsolete_categories.each { |name| say("  remove empty category #{name}") }
+        counts = { copied: plan.copy.size, recategorized: plan.recategorize.size, removed_categories: plan.obsolete_categories.size }
       else
         syncer.apply!
+        counts = syncer.applied
       end
 
-      say("Copied #{plan.copy.size - syncer.copy_failures.size}, recategorized #{plan.recategorize.size}, removed #{plan.obsolete_categories.size} empty categories#{dry_run_mode_suffix}", :green)
+      say("Copied #{counts[:copied]}, recategorized #{counts[:recategorized]}, removed #{counts[:removed_categories]} empty categories#{dry_run_mode_suffix}", :green)
 
       syncer.copy_failures.each { |failure| say("Failed to copy #{failure[:shortcode]}: #{failure[:message]}", :red) }
 
       say("#{plan.awaiting_federation.size} emoji on #{syncer.domain} have not federated here yet, post them there to bring them over: #{summarize_shortcodes(plan.awaiting_federation)}", :yellow) if plan.awaiting_federation.any?
       say("#{plan.orphans.size} local emoji are unknown to #{syncer.domain} and were left untouched: #{summarize_shortcodes(plan.orphans)}", :yellow) if plan.orphans.any?
-      say("#{plan.unsyncable.size} emoji on #{syncer.domain} cannot be represented here, names must match #{CustomEmoji::SHORTCODE_RE_FRAGMENT}: #{summarize_shortcodes(plan.unsyncable)}", :yellow) if plan.unsyncable.any?
+      say("#{plan.unsyncable.size} emoji on #{syncer.domain} cannot be represented here, names must match #{CustomEmoji::SHORTCODE_RE_FRAGMENT} and be at most #{CustomEmoji::MAX_SHORTCODE_SIZE} characters: #{summarize_shortcodes(plan.unsyncable)}", :yellow) if plan.unsyncable.any?
     rescue MisskeyEmojiSync::Error => e
       fail_with_message e.message
     end

--- a/lib/mastodon/cli/emoji.rb
+++ b/lib/mastodon/cli/emoji.rb
@@ -167,7 +167,9 @@ module Mastodon::CLI
         syncer.apply!
       end
 
-      say("Copied #{plan.copy.size}, recategorized #{plan.recategorize.size}, removed #{plan.obsolete_categories.size} empty categories#{dry_run_mode_suffix}", :green)
+      say("Copied #{plan.copy.size - syncer.copy_failures.size}, recategorized #{plan.recategorize.size}, removed #{plan.obsolete_categories.size} empty categories#{dry_run_mode_suffix}", :green)
+
+      syncer.copy_failures.each { |failure| say("Failed to copy #{failure[:shortcode]}: #{failure[:message]}", :red) }
 
       say("#{plan.awaiting_federation.size} emoji on #{syncer.domain} have not federated here yet, post them there to bring them over: #{summarize_shortcodes(plan.awaiting_federation)}", :yellow) if plan.awaiting_federation.any?
       say("#{plan.orphans.size} local emoji are unknown to #{syncer.domain} and were left untouched: #{summarize_shortcodes(plan.orphans)}", :yellow) if plan.orphans.any?

--- a/spec/fork/misskey_emoji_sync_spec.rb
+++ b/spec/fork/misskey_emoji_sync_spec.rb
@@ -174,6 +174,14 @@ RSpec.describe MisskeyEmojiSync do
         expect { syncer.apply! }.to change { emoji.reload.category.name }.from('Stale').to('Greetings')
         expect(syncer.copy_failures.pluck(:shortcode)).to eq ['broken']
       end
+
+      # 計画は 2 件の張り替えを含むが、コピーに失敗した側は実施されない
+      it 'counts only what it actually wrote' do
+        syncer.apply!
+
+        expect(syncer.plan.recategorize.size).to eq 2
+        expect(syncer.applied).to eq({ copied: 0, recategorized: 1, removed_categories: 1 })
+      end
     end
 
     context 'with a category whose featured emoji moved away' do
@@ -213,6 +221,16 @@ RSpec.describe MisskeyEmojiSync do
         expect { subject }
           .to output_results('Copied 0, recategorized 1, removed 1 empty categories')
           .and change { emoji.reload.category.name }.from('Stale').to('Greetings')
+      end
+    end
+
+    # 128 文字超の名前は正規表現のほうは満たすので、字面だけでは弾かれた理由が分からない
+    context 'with an unsyncable name on the origin' do
+      let(:origin_emojis) { [{ name: 'kept', category: 'Greetings' }, { name: 'x' * (CustomEmoji::MAX_SHORTCODE_SIZE + 1), category: 'Greetings' }] }
+
+      it 'states the length limit alongside the pattern' do
+        expect { subject }
+          .to output_results("must match #{CustomEmoji::SHORTCODE_RE_FRAGMENT} and be at most #{CustomEmoji::MAX_SHORTCODE_SIZE} characters")
       end
     end
 

--- a/spec/fork/misskey_emoji_sync_spec.rb
+++ b/spec/fork/misskey_emoji_sync_spec.rb
@@ -90,6 +90,20 @@ RSpec.describe MisskeyEmojiSync do
       end
     end
 
+    # ローカル絵文字は 128 文字まで、リモート絵文字は 2048 文字まで。長すぎる名前を
+    # syncable と誤判定すると copy! が検証で落ちる（#946 の Codex 指摘）
+    context 'with an emoji on the origin whose name is too long for a local shortcode' do
+      let(:long_name) { 'x' * (CustomEmoji::MAX_SHORTCODE_SIZE + 1) }
+      let(:origin_emojis) { [{ name: long_name, category: 'Greetings' }] }
+
+      before { Fabricate(:custom_emoji, shortcode: long_name, domain: 'misskey.example') }
+
+      it 'reports it as unsyncable instead of planning to copy it' do
+        expect(syncer.plan.unsyncable).to eq [long_name]
+        expect(syncer.plan.copy).to be_empty
+      end
+    end
+
     context 'when the origin cannot be reached' do
       before { stub_request(:get, 'https://misskey.example/api/emojis').to_return(status: 500) }
 
@@ -142,6 +156,23 @@ RSpec.describe MisskeyEmojiSync do
         expect { syncer.apply! }
           .to not_change { emoji.reload.category.name }
           .and(not_change { CustomEmoji.local.count })
+      end
+    end
+
+    # コピー 1 件の失敗で本命のカテゴリ同期まで落とさないこと
+    context 'when copying one emoji fails' do
+      let(:origin_emojis) { [{ name: 'kept', category: 'Greetings' }, { name: 'broken', category: 'Greetings' }] }
+      let!(:emoji) { Fabricate(:custom_emoji, shortcode: 'kept', category: Fabricate(:custom_emoji_category, name: 'Stale')) }
+
+      before do
+        Fabricate(:custom_emoji, shortcode: 'broken', domain: 'misskey.example')
+        broken = syncer.plan.copy.find { |candidate| candidate.shortcode == 'broken' }
+        allow(broken).to receive(:copy!).and_raise(ActiveRecord::RecordInvalid.new(CustomEmoji.new.tap(&:validate)))
+      end
+
+      it 'records the failure and still syncs categories' do
+        expect { syncer.apply! }.to change { emoji.reload.category.name }.from('Stale').to('Greetings')
+        expect(syncer.copy_failures.pluck(:shortcode)).to eq ['broken']
       end
     end
 


### PR DESCRIPTION
[PR #946 への Codex 指摘](https://github.com/pooza/mastodon/pull/946#discussion_r3724813397)（P2）への対応。

## 指摘の検証

**ダイスキー相手には発生しない。** Misskey の絵文字名カラムは `varchar(128)`（`packages/backend/src/models/Emoji.ts`）で、Mastodon のローカル上限 `MAX_SHORTCODE_SIZE = 128` と一致するため、129〜2048 文字の名前は向こうに存在し得ない。

ただし指摘の筋は通っている。同期可否を `SHORTCODE_ONLY_RE` だけで判定しており、長さの不変条件を Misskey 側のスキーマに暗黙に依存させていた。この一致は保証ではないので自分で弾く。

## 直したこと

1. **長さ判定を追加** — `syncable_shortcode?` でローカル上限 128 文字を見る。超えるものは `plan.copy` に入れず `unsyncable` として報告する
2. **コピー失敗で全体を止めない** — Codex が指摘した「同期全体が中断する」ほうが本質的な問題。本命はカテゴリ同期なので、`copy!` の `RecordInvalid` は `copy_failures` に記録して続行し、最後に赤で報告する。cron で回す以上、1 件の異常で全部が止まるのは筋が悪い

2 に伴い、カテゴリ張り替えの `find_by!` を `find_by` + skip に変えた（コピーに失敗した絵文字はローカルに存在しないため）。

## テスト

`spec/fork/misskey_emoji_sync_spec.rb` に 2 例追加。

- 129 文字の名前が `unsyncable` に入り `copy` に入らない
- コピー 1 件が失敗しても他のカテゴリ同期は完走し、失敗が `copy_failures` に残る

```
bundle exec rspec spec/fork
35 examples, 0 failures
```