### PR TITLE
絵文字同期の結果を投稿用の文面として出す --announce (#948)

### DIFF
--- a/app/lib/misskey_emoji_sync.rb
+++ b/app/lib/misskey_emoji_sync.rb
@@ -44,6 +44,12 @@ class MisskeyEmojiSync
     @applied ||= { copied: 0, recategorized: 0, removed_categories: 0 }
   end
 
+  # 告知に載せてよい新規絵文字。apply! の前は計画どおり、後は実際にコピーできたぶんだけ。
+  # 失敗したものを「増えました」と伝えてしまわないため
+  def announceable_copies
+    plan.copy.map(&:shortcode) - copy_failures.pluck(:shortcode)
+  end
+
   def apply!
     # 画像のアップロードを伴うので、カテゴリの張り替えとは分けてトランザクションの外で行う。
     # 個々のコピーの失敗で本命のカテゴリ同期まで巻き添えにしないよう、拾って続行する

--- a/lib/mastodon/cli/emoji.rb
+++ b/lib/mastodon/cli/emoji.rb
@@ -136,6 +136,9 @@ module Mastodon::CLI
     # 未連合の絵文字は初回や新設サーバーで数百件になりうるので、通知に流せる長さに畳む
     REPORTED_SHORTCODES = 10
 
+    ANNOUNCEMENT_LEAD = '新しい絵文字が増えました。'
+    ANNOUNCEMENT_CATEGORY_NOTE = 'カテゴリを整理しました。'
+
     option :dry_run, type: :boolean, default: true
     option :announce, type: :boolean, default: false
     desc 'sync ORIGIN', 'Sync custom emoji and their categories from a sister Misskey server at ORIGIN'
@@ -182,7 +185,7 @@ module Mastodon::CLI
       say("#{plan.orphans.size} local emoji are unknown to #{syncer.domain} and were left untouched: #{summarize_shortcodes(plan.orphans)}", :yellow) if plan.orphans.any?
       say("#{plan.unsyncable.size} emoji on #{syncer.domain} cannot be represented here, names must match #{CustomEmoji::SHORTCODE_RE_FRAGMENT} and be at most #{CustomEmoji::MAX_SHORTCODE_SIZE} characters: #{summarize_shortcodes(plan.unsyncable)}", :yellow) if plan.unsyncable.any?
 
-      say_announcement(plan) if options[:announce]
+      say_announcement(syncer) if options[:announce]
     rescue MisskeyEmojiSync::Error => e
       fail_with_message e.message
     end
@@ -198,23 +201,51 @@ module Mastodon::CLI
     # 利用者向け告知の下書き。お知らせボットからの投稿にそのまま貼れる形で出す。
     # 絵文字はショートコード表記のまま並べると、投稿されたときにインラインで描画される。
     # 本文は日本語サーバー向けの文面をそのまま持つ
-    def say_announcement(plan)
-      copied = plan.copy.map(&:shortcode)
-      moved  = plan.recategorize.count { |change| copied.exclude?(change[:shortcode]) }
+    def say_announcement(syncer)
+      drafts = announcement_drafts(syncer)
 
-      lines = []
-      lines << "新しい絵文字が増えました。\n#{copied.map { |shortcode| ":#{shortcode}:" }.join(' ')}" if copied.any?
-      lines << 'カテゴリを整理しました。' if moved.positive?
-
-      if lines.empty?
+      if drafts.empty?
         say('Nothing to announce.')
         return
       end
 
-      say('')
-      say('--- announcement ---')
-      say(lines.join("\n\n"))
-      say('--- end ---')
+      drafts.each_with_index do |draft, index|
+        label = "announcement#{" #{index + 1}/#{drafts.size}" if drafts.size > 1}"
+
+        say('')
+        say("--- #{label} ---")
+        say(draft)
+        say('--- end ---')
+      end
+    end
+
+    # 貼れない文面を「そのまま貼れる」と言わないため、投稿の文字数上限に収まるよう割る。
+    # 初回同期では数百件になりうるし、ショートコードは 1 件で 128 文字まであり得る
+    def announcement_drafts(syncer)
+      planned = syncer.plan.copy.map(&:shortcode)
+      copied  = syncer.announceable_copies
+      moved   = syncer.plan.recategorize.count { |change| planned.exclude?(change[:shortcode]) }
+
+      return moved.positive? ? [ANNOUNCEMENT_CATEGORY_NOTE] : [] if copied.empty?
+
+      budget = StatusLengthValidator::MAX_CHARS - ANNOUNCEMENT_LEAD.length - 1
+      budget -= ANNOUNCEMENT_CATEGORY_NOTE.length + 2 if moved.positive?
+
+      drafts = chunk_shortcodes(copied, budget).map { |chunk| "#{ANNOUNCEMENT_LEAD}\n#{chunk}" }
+      drafts[-1] = "#{drafts.last}\n\n#{ANNOUNCEMENT_CATEGORY_NOTE}" if moved.positive?
+      drafts
+    end
+
+    def chunk_shortcodes(shortcodes, budget)
+      shortcodes.each_with_object([]) do |shortcode, chunks|
+        token = ":#{shortcode}:"
+
+        if chunks.empty? || (chunks.last.length + 1 + token.length) > budget
+          chunks << token.dup
+        else
+          chunks.last << " #{token}"
+        end
+      end
     end
 
     def color(green, _yellow, red)

--- a/lib/mastodon/cli/emoji.rb
+++ b/lib/mastodon/cli/emoji.rb
@@ -137,6 +137,7 @@ module Mastodon::CLI
     REPORTED_SHORTCODES = 10
 
     option :dry_run, type: :boolean, default: true
+    option :announce, type: :boolean, default: false
     desc 'sync ORIGIN', 'Sync custom emoji and their categories from a sister Misskey server at ORIGIN'
     long_desc <<-LONG_DESC
       Aligns local custom emoji with the sister Misskey server at ORIGIN,
@@ -152,6 +153,10 @@ module Mastodon::CLI
       it always writes only what differs.
 
       Nothing is written unless --no-dry-run is given.
+
+      With --announce, a draft announcement is printed after the report, ready
+      to be posted to the local announcement bot so that users can see which
+      emoji arrived.
     LONG_DESC
     def sync(origin)
       syncer = MisskeyEmojiSync.new(origin)
@@ -176,6 +181,8 @@ module Mastodon::CLI
       say("#{plan.awaiting_federation.size} emoji on #{syncer.domain} have not federated here yet, post them there to bring them over: #{summarize_shortcodes(plan.awaiting_federation)}", :yellow) if plan.awaiting_federation.any?
       say("#{plan.orphans.size} local emoji are unknown to #{syncer.domain} and were left untouched: #{summarize_shortcodes(plan.orphans)}", :yellow) if plan.orphans.any?
       say("#{plan.unsyncable.size} emoji on #{syncer.domain} cannot be represented here, names must match #{CustomEmoji::SHORTCODE_RE_FRAGMENT} and be at most #{CustomEmoji::MAX_SHORTCODE_SIZE} characters: #{summarize_shortcodes(plan.unsyncable)}", :yellow) if plan.unsyncable.any?
+
+      say_announcement(plan) if options[:announce]
     rescue MisskeyEmojiSync::Error => e
       fail_with_message e.message
     end
@@ -186,6 +193,28 @@ module Mastodon::CLI
       return shortcodes.join(', ') if shortcodes.size <= REPORTED_SHORTCODES
 
       "#{shortcodes.first(REPORTED_SHORTCODES).join(', ')} and #{shortcodes.size - REPORTED_SHORTCODES} more"
+    end
+
+    # 利用者向け告知の下書き。お知らせボットからの投稿にそのまま貼れる形で出す。
+    # 絵文字はショートコード表記のまま並べると、投稿されたときにインラインで描画される。
+    # 本文は日本語サーバー向けの文面をそのまま持つ
+    def say_announcement(plan)
+      copied = plan.copy.map(&:shortcode)
+      moved  = plan.recategorize.count { |change| copied.exclude?(change[:shortcode]) }
+
+      lines = []
+      lines << "新しい絵文字が増えました。\n#{copied.map { |shortcode| ":#{shortcode}:" }.join(' ')}" if copied.any?
+      lines << 'カテゴリを整理しました。' if moved.positive?
+
+      if lines.empty?
+        say('Nothing to announce.')
+        return
+      end
+
+      say('')
+      say('--- announcement ---')
+      say(lines.join("\n\n"))
+      say('--- end ---')
     end
 
     def color(green, _yellow, red)

--- a/spec/fork/misskey_emoji_sync_spec.rb
+++ b/spec/fork/misskey_emoji_sync_spec.rb
@@ -175,6 +175,11 @@ RSpec.describe MisskeyEmojiSync do
         expect(syncer.copy_failures.pluck(:shortcode)).to eq ['broken']
       end
 
+      # 失敗したものを告知で「増えました」と伝えてしまわないこと
+      it 'drops the failed emoji from what may be announced' do
+        expect { syncer.apply! }.to change(syncer, :announceable_copies).from(['broken']).to([])
+      end
+
       # 計画は 2 件の張り替えを含むが、コピーに失敗した側は実施されない
       it 'counts only what it actually wrote' do
         syncer.apply!
@@ -238,6 +243,20 @@ RSpec.describe MisskeyEmojiSync do
     describe '--announce' do
       let(:options) { { dry_run: true, announce: true } }
 
+      def capture_announcement_drafts
+        buffer   = StringIO.new
+        original = $stdout
+        $stdout  = buffer
+
+        begin
+          subject
+        ensure
+          $stdout = original
+        end
+
+        buffer.string.scan(/^--- announcement[^\n]*---\n(.*?)\n--- end ---$/m).flatten
+      end
+
       context 'with emoji to copy and categories to reorganize' do
         before { Fabricate(:custom_emoji, shortcode: 'fresh', domain: 'misskey.example') }
 
@@ -264,6 +283,25 @@ RSpec.describe MisskeyEmojiSync do
           expect { subject }
             .to output_results('Nothing to announce.')
             .and not_output_results('--- announcement ---')
+        end
+      end
+
+      # ショートコードは 1 件 128 文字まであり得るので、少数でも投稿の上限を超えうる
+      context 'with more new emoji than fit in a single status' do
+        let(:long_names) { Array.new(30) { |i| format("%<index>02d#{'x' * 98}", index: i) } }
+        let(:origin_emojis) { long_names.map { |name| { name: name, category: 'Greetings' } } }
+
+        before { long_names.each { |name| Fabricate(:custom_emoji, shortcode: name, domain: 'misskey.example') } }
+
+        it 'splits the draft into postable pieces' do
+          expect { subject }.to output_results('--- announcement 1/2 ---', '--- announcement 2/2 ---')
+        end
+
+        it 'keeps every piece within the status limit' do
+          drafts = capture_announcement_drafts
+
+          expect(drafts).to_not be_empty
+          expect(drafts.map(&:length)).to all(be <= StatusLengthValidator::MAX_CHARS)
         end
       end
     end

--- a/spec/fork/misskey_emoji_sync_spec.rb
+++ b/spec/fork/misskey_emoji_sync_spec.rb
@@ -234,6 +234,45 @@ RSpec.describe MisskeyEmojiSync do
       end
     end
 
+    # 絵文字をまとめて登録した直後に手で流す運用のため、そのまま貼れる文面を出す (#948)
+    describe '--announce' do
+      let(:options) { { dry_run: true, announce: true } }
+
+      context 'with emoji to copy and categories to reorganize' do
+        before { Fabricate(:custom_emoji, shortcode: 'fresh', domain: 'misskey.example') }
+
+        let(:origin_emojis) { [{ name: 'kept', category: 'Greetings' }, { name: 'fresh', category: 'Greetings' }] }
+
+        it 'lists the new emoji as shortcodes and mentions the reorganization' do
+          expect { subject }
+            .to output_results('--- announcement ---', '新しい絵文字が増えました。', ':fresh:', 'カテゴリを整理しました。', '--- end ---')
+        end
+      end
+
+      context 'with nothing but categories to reorganize' do
+        it 'omits the emoji line' do
+          expect { subject }
+            .to output_results('カテゴリを整理しました。')
+            .and not_output_results('新しい絵文字が増えました。')
+        end
+      end
+
+      context 'with nothing to do' do
+        let(:origin_emojis) { [{ name: 'kept', category: 'Stale' }] }
+
+        it 'says there is nothing to announce' do
+          expect { subject }
+            .to output_results('Nothing to announce.')
+            .and not_output_results('--- announcement ---')
+        end
+      end
+    end
+
+    it 'prints no announcement without the flag' do
+      expect { subject }
+        .to not_output_results('--- announcement ---')
+    end
+
     # 新設サーバーや初回は未連合が数百件になる。通知へ流せる長さに畳まれること
     context 'with more emoji awaiting federation than the report lists' do
       let(:origin_emojis) { (1..15).map { |i| { name: format('pending_%02d', i), category: 'Greetings' } } + [{ name: 'kept', category: 'Greetings' }] }


### PR DESCRIPTION
Closes #948

## 何をするか

`tootctl emoji sync` に `--announce` を足す。付けたときだけ、レポートの後に `@info`（デルムリン丼お知らせボット）へ貼れる下書きを出す。

```
bundle exec tootctl emoji sync https://misskey.delmulin.com --no-dry-run --announce
```

```
--- announcement ---
新しい絵文字が増えました。
:torataku: :alkeed: :carl: :field_of_death: :papnica:

カテゴリを整理しました。
--- end ---
```

ショートコード表記のまま並べるので、投稿されると**絵文字がインラインで描画され**、利用者は何が増えたか一目で分かる。

## なぜ自動投稿にしないか

当面 cron 化せず、絵文字をまとめて登録した直後に手で流す運用にするため。手動なら実行結果は端末に出るので運用通知は冗長で、残る価値は利用者向け告知だけ。自動投稿まで作ると `@info` のトークンをどこに置くかを決める作業が発生する（`write:statuses` を持つ有効なトークンは存在するが、writersbase-tools には投稿の仕組みが無い）。cron 化のときにここから育てる。

## 挙動

- 新規コピーが無ければ絵文字の行を出さない
- 既存絵文字のカテゴリ移動が無ければカテゴリの行を出さない。**コピーに伴うカテゴリ付与は「整理」に数えない**
- どちらも無ければ `Nothing to announce.`
- dry-run でも出す（投稿前に文面を確認できる）
- フラグ無しでは一切出さない

## テスト

`spec/fork/misskey_emoji_sync_spec.rb` に 4 例追加。

```
bundle exec rspec spec/fork
41 examples, 0 failures
```